### PR TITLE
chore(ci): add stale action

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -62,3 +62,5 @@
   color: '80c042'
 - name: wontfix
   color: 'ffffff'
+- name: stale
+  color: 'ead18c'

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,22 @@
+staleLabel: stale
+exemptLabels:
+  - has PR
+  - in progress
+  - in review
+
+pulls:
+  daysUntilStale: 60
+  daysUntilClose: 14
+  markComment: >
+    This pull has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+  closeComment: false
+issues:
+  daysUntilStale: 90
+  daysUntilClose: 14
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+  closeComment: false


### PR DESCRIPTION
* Adds `stale` actions. Automatically attach stale labels exempt labeled `has PR`, `in progress`, or `in review`.
* Adds `stale` labels