### PR TITLE
chore: enable "autoMerge" without any tests by invalidate `requiredStatusChecks`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
     ":disableDependencyDashboard",
     "helpers:pinGitHubActionDigests"
   ],
+  "requiredStatusChecks": null,
   "timezone": "Asia/Seoul",
   "assignees": ["Sayakie"],
   "automergeType": "pr",


### PR DESCRIPTION
See more context in:
* renovatebot/renovate#351
* renovatebot/config-help#639